### PR TITLE
Fix cache file date

### DIFF
--- a/src/get-data.ts
+++ b/src/get-data.ts
@@ -102,6 +102,14 @@ async function getFromServer(): Promise<FetchResult> {
 }
 
 function getCacheFileName(): string {
-  const date = new Date().toLocaleDateString("sv-SE");
-  return `${date}.txt`;
+  return `${getCurrentDate()}.txt`;
+}
+
+function getCurrentDate(): string {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  return `${year}-${month}-${day}`;
 }


### PR DESCRIPTION
`localeDatestring` doesn't work in nodejs